### PR TITLE
Add scheme to 'Cloud Resume Challenge' url

### DIFF
--- a/resumesite/resumesitehtml/blog/hello-world/index.html
+++ b/resumesite/resumesitehtml/blog/hello-world/index.html
@@ -52,7 +52,7 @@
       Needless to say, I had never done anything like this before - but I saw it as a opportunity to build on my learning. It was a huge challenge, and took me several weeks alongside my coursework to complete. There where many evenings when I had absolutely no clue how to tackle the next step. But with a little bit of research and a lot of head-scratching and persistence, I'm happy to report I overcame the challenge! I'll go deeper into specific challenges I faced during this project in my next post.</p>
       <img src="images/architecture.png" alt="Certified Cloud Practioner Badge" class="architecture"><br>
       <p>I made this diagram showing my architecture and you can see the finished project <a href="/">here</a>. It was such a rewarding experience and my confidence in my practical skills has skyrocketed.<br><br> 
-      If you've made it this far - I highly recommend the challenge if you're looking to test your skills! There's a supportive community and a plethora of learning materials available at the <a href="cloudresumechallenge.dev/docs/the-challenge/">Cloud Resume Challenge</a>. Finally, I'd like to thank Forest Brazeal and the CRC community for their efforts in making the cloud accessible to all.<br>
+      If you've made it this far - I highly recommend the challenge if you're looking to test your skills! There's a supportive community and a plethora of learning materials available at the <a href="https://cloudresumechallenge.dev/docs/the-challenge/">Cloud Resume Challenge</a>. Finally, I'd like to thank Forest Brazeal and the CRC community for their efforts in making the cloud accessible to all.<br>
     </p>
 </div>
 <hr class="descriptionline">


### PR DESCRIPTION
So that it no longer creates 'https://www.thomasbaldock.com/blog/hello-world/cloudresumechallenge.dev/docs/the-challenge/' as the (incorrect) link.